### PR TITLE
emptyRequest option not works

### DIFF
--- a/src/js/ajaxSelectPicker.defaults.js
+++ b/src/js/ajaxSelectPicker.defaults.js
@@ -72,6 +72,14 @@ $.fn.ajaxSelectPicker.defaults = {
 
     /**
      * @member $.fn.ajaxSelectPicker.defaults
+     * @cfg {Boolean} clearOnError = true
+     * @markdown
+     * Clears the select list when the request returned with an error.
+     */
+    clearOnError: true,
+
+    /**
+     * @member $.fn.ajaxSelectPicker.defaults
      * @cfg {Boolean} debug
      * @deprecated Since version `1.2.0`, see: {@link $.fn.ajaxSelectPicker.defaults#log}.
      */
@@ -252,6 +260,15 @@ $.fn.ajaxSelectPicker.defaults = {
      * current delayed request and start a new one.
      */
     requestDelay: 300,
+
+    /**
+     * @member $.fn.ajaxSelectPicker.defaults
+     * @cfg {Boolean} restoreOnError = false
+     * @markdown
+     * Restores the select list with the previous results when the request
+     * returns with an error.
+     */
+    restoreOnError: false,
 
     /**
      * @member $.fn.ajaxSelectPicker.defaults

--- a/src/js/ajaxSelectPicker.locale/en-US.js
+++ b/src/js/ajaxSelectPicker.locale/en-US.js
@@ -36,6 +36,14 @@ $.fn.ajaxSelectPicker.locale['en-US'] = {
 
     /**
      * @member $.fn.ajaxSelectPicker.locale
+     * @cfg {String} errorText = ''Unable to retrieve results'
+     * @markdown
+     * The text to use in the status container when a request returns with an error.
+     */
+    errorText: 'Unable to retrieve results',
+
+    /**
+     * @member $.fn.ajaxSelectPicker.locale
      * @cfg {String} searchPlaceholder = 'Search...'
      * @markdown
      * The text to use for the search input placeholder attribute.

--- a/src/js/classes/AjaxBootstrapSelectList.js
+++ b/src/js/classes/AjaxBootstrapSelectList.js
@@ -25,7 +25,7 @@ var AjaxBootstrapSelectList = function (plugin) {
      * Container for cached data.
      * @type {Object}
      */
-    this.cache = { '': [] };
+    this.cache = {};
 
     /**
      * Reference the plugin for internal use.
@@ -267,7 +267,8 @@ AjaxBootstrapSelectList.prototype.replaceOptions = function (data) {
  *   Return true if successful or false if no states are present.
  */
 AjaxBootstrapSelectList.prototype.restore = function () {
-    if (this.plugin.list.replaceOptions(this.plugin.list.cacheGet(this.plugin.previousQuery))) {
+    var cache = this.plugin.list.cacheGet(this.plugin.previousQuery);
+    if (cache && this.plugin.list.replaceOptions(cache)) {
         this.plugin.log(this.plugin.LOG_DEBUG, 'Restored select list to the previous query: ', this.plugin.previousQuery);
     }
     this.plugin.log(this.plugin.LOG_DEBUG, 'Unable to restore select list to the previous query:', this.plugin.previousQuery);

--- a/src/js/classes/AjaxBootstrapSelectRequest.js
+++ b/src/js/classes/AjaxBootstrapSelectRequest.js
@@ -125,7 +125,22 @@ AjaxBootstrapSelectRequest.prototype.complete = function (jqXHR, status) {
  * @return {void}
  */
 AjaxBootstrapSelectRequest.prototype.error = function (jqXHR, status, error) {
-    this.plugin.list.restore();
+    // Cache the result data.
+    this.plugin.list.cacheSet(this.plugin.query);
+
+    // Clear the list.
+    if (this.plugin.options.clearOnError) {
+        this.plugin.list.destroy();
+    }
+
+    // Set the status after the list has cleared and before the restore.
+    this.plugin.list.setStatus(this.plugin.t('errorText'));
+
+    // Restore previous request.
+    if (this.plugin.options.restoreOnError) {
+        this.plugin.list.restore();
+        this.plugin.list.setStatus();
+    }
 };
 
 /**


### PR DESCRIPTION
Fixes #17 

This introduces a couple new options and new locale string for better handling errors (encountered this because the TMDb API returns a 404 for empty requests).
