### PR TITLE
preserve selected options for server generated html

### DIFF
--- a/src/js/classes/AjaxBootstrapSelectList.js
+++ b/src/js/classes/AjaxBootstrapSelectList.js
@@ -55,8 +55,8 @@ var AjaxBootstrapSelectList = function (plugin) {
             text: $option.text(),
             'class': $option.attr('class') || '',
             data: $option.data() || {},
-            preserved: false,
-            selected: false
+            preserved: plugin.options.preserveSelected,
+            selected: !!$option.attr('selected')
         });
     });
     this.cacheSet(/*query=*/'', initial_options);

--- a/src/js/classes/AjaxBootstrapSelectList.js
+++ b/src/js/classes/AjaxBootstrapSelectList.js
@@ -63,6 +63,7 @@ var AjaxBootstrapSelectList = function (plugin) {
 
     // Preserve selected options.
     if (plugin.options.preserveSelected) {
+        that.selected = initial_options;
         plugin.$element.on('change.abs.preserveSelected', function (e) {
             var $selected = plugin.$element.find(':selected');
             that.selected = [];


### PR DESCRIPTION
building on top of #55 

this fixes the issue that the initial `<option>` elements in the server generated html disappear when the user selects an element from the search result list even though `preserveSelected` is `true`