### PR TITLE
Ensure "text" attribute is used

### DIFF
--- a/src/js/classes/AjaxBootstrapSelectList.js
+++ b/src/js/classes/AjaxBootstrapSelectList.js
@@ -133,7 +133,7 @@ AjaxBootstrapSelectList.prototype.build = function (data) {
         }
 
         // Set various properties.
-        $option.val(item.value).text(item.text);
+        $option.val(item.value).text(item.text).attr('title', item.text);
         if (item['class'].length) {
             $option.attr('class', item['class']);
         }


### PR DESCRIPTION
This commit ensures the "text" attribute is used by bootstrap-select to display the text in the selectbox even when data-content is used.