### PR TITLE
Fix statusToShort -> statusTooShort

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ See: [options.locale](#optionslocale)
 
 ***
 
-#### locale.statusToShort
+#### locale.statusTooShort
 > __Type:__ `String`
 >
 > __Default:__ `'Please enter more characters'`


### PR DESCRIPTION
## Description (required)

Fix on locale.statusTooShort because the option was spelled wrong(locale.statusToShort).