### PR TITLE
Fix the obfuscation of the status message for longer dropdowns

### DIFF
--- a/src/js/classes/AjaxBootstrapSelectList.js
+++ b/src/js/classes/AjaxBootstrapSelectList.js
@@ -353,7 +353,7 @@ AjaxBootstrapSelectList.prototype.setStatus = function (status) {
         // options list is longer than the maxHeight set on the dropdown
         var maxHeight = this.$status.parent('.dropdown-menu').css('maxHeight');
         this.$status.parent('.dropdown-menu').css({
-            maxHeight: parseInt(maxHeight) + this.$status.outerHeight() + 'px'
+            maxHeight: parseInt(maxHeight, 10) + this.$status.outerHeight() + 'px'
         });
     }
     else {


### PR DESCRIPTION
## Description (required)

When a status message is displayed for an options list that is longer than the `maxHeight` of the dropdown, it is cut off because the dropdown isn't taking the status height into account.  This pull request adds the height of the status box to the `maxHeight` of the dropdown.

## Screenshots (optional)

***Before***
<img width="484" alt="screen shot 2018-07-24 at 3 24 58 pm" src="https://user-images.githubusercontent.com/451965/43161349-dd5678a2-8f55-11e8-8bbf-7111c4339707.png">

***After***
<img width="479" alt="screen shot 2018-07-24 at 3 24 20 pm" src="https://user-images.githubusercontent.com/451965/43161362-e7d201d4-8f55-11e8-96aa-e7979db3ed6f.png">

## Merge checklist (required, for maintainers only)

This pull request adheres to the following requirements:

- [] JavaScript follows 4 space indentation conventions.
- [] JavaScript was written using ES2015 (ES6) features.
- [] Features and bug fixes are covered by test cases.
- [] All commits follow the _AngularJS Git Commit Message Conventions_.
