### PR TITLE
Move minLength check below clearTimeout & empty query check

### DIFF
--- a/src/js/classes/AjaxBootstrapSelect.js
+++ b/src/js/classes/AjaxBootstrapSelect.js
@@ -312,12 +312,6 @@ AjaxBootstrapSelect.prototype.init = function () {
             plugin.log(plugin.LOG_DEBUG, 'Key ignored.');
             return;
         }
-		
-        // Don't process if below minimum query length
-        if (query.length < plugin.options.minLength) {
-            plugin.list.setStatus(plugin.t('statusTooShort'));
-            return;
-        }
 
         // Clear out any existing timer.
         clearTimeout(requestDelayTimer);
@@ -333,6 +327,12 @@ AjaxBootstrapSelect.prototype.init = function () {
             if (!plugin.options.emptyRequest) {
                 return;
             }
+        }
+
+        // Don't process if below minimum query length
+        if (query.length < plugin.options.minLength) {
+            plugin.list.setStatus(plugin.t('statusTooShort'));
+            return;
         }
 
         // Store the query.


### PR DESCRIPTION
## Description (required)

This fixes an issue in which backspace causes a search to occur when the query hits `minLength` while still backspacing.  It also fixes the case in which clearing the list is ignored for an empty query when `minLength` is set.

## Closes Issue (optional)
Closes #155  

## Merge checklist (required, for maintainers only)

This pull request adheres to the following requirements:

- [] JavaScript follows 4 space indentation conventions.
- [] JavaScript was written using ES2015 (ES6) features.
- [] Features and bug fixes are covered by test cases.
- [] All commits follow the _AngularJS Git Commit Message Conventions_.
