### PR TITLE
 Changed to path relative to dist folder, in the example.

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -5,7 +5,7 @@
     <title></title>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.6.3/css/bootstrap-select.min.css"/>
-    <link rel="stylesheet" href="/dist/css/ajax-bootstrap-select.css"/>
+    <link rel="stylesheet" href="../dist/css/ajax-bootstrap-select.css"/>
     <style>h3 {
             text-align: center;
         }
@@ -156,7 +156,7 @@
         src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/js/bootstrap.min.js"></script>
 <script type="text/javascript"
         src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.6.3/js/bootstrap-select.min.js"></script>
-<script type="text/javascript" src="/dist/js/ajax-bootstrap-select.js"></script>
+<script type="text/javascript" src="../dist/js/ajax-bootstrap-select.js"></script>
 <script>
     var options = {
         ajax          : {


### PR DESCRIPTION
When you opened the example, in a path other than root, it was executed in error while getting files from the dist folder.
Before:  http://127.0.0.1/dist/css/ajax-bootstrap-select.css net::ERR_ABORTED 404 (Not Found)
After: Is loaded correctly

## Description (required)

Fix loading files from dist folder, for example

## Screenshots (optional)
Before:
![image](https://user-images.githubusercontent.com/16328403/62005524-ed44a900-b10a-11e9-9eec-71ca543519a7.png)

After:
![image](https://user-images.githubusercontent.com/16328403/62005537-0a797780-b10b-11e9-801f-3277315e6af7.png)
