### PR TITLE
Trigger refresh when there aren't any results

### DIFF
--- a/src/js/classes/AjaxBootstrapSelectRequest.js
+++ b/src/js/classes/AjaxBootstrapSelectRequest.js
@@ -104,7 +104,6 @@ AjaxBootstrapSelectRequest.prototype.complete = function (jqXHR, status) {
                 this.plugin.list.destroy();
                 this.plugin.list.setStatus(this.plugin.t('statusNoResults'));
                 this.plugin.log(this.plugin.LOG_INFO, 'No results were returned.');
-                return;
             }
         }
         this.plugin.list.refresh(true);


### PR DESCRIPTION
Implementation for `statusNoResults` scenario was not following same behavior as when results are found. jQuery/bootstrap `change` event didn't get triggered when no results were found, while it did get triggered when results were found, which is inconsistent. (see point 3)

This change solves the following:

1. User searches for something and results were found and returned
2. User selects an option and `change` event is triggered
3. User searches for something new and no results were found. All selected options get reset, but  `change`  event is NOT triggered.

