### PR TITLE
Make the change event triggering configurable

### DIFF
--- a/src/js/ajaxSelectPicker.defaults.js
+++ b/src/js/ajaxSelectPicker.defaults.js
@@ -292,5 +292,13 @@ $.fn.ajaxSelectPicker.defaults = {
      */
     templates: {
         status: '<div class="status"></div>'
-    }
+    },
+
+    /**
+     * @member $.fn.ajaxSelectPicker.defaults
+     * @cfg {Boolean} triggerChange = false
+     * @markdown
+     * Trigger change event when specified.
+     */
+    triggerChange: false
 };

--- a/src/js/classes/AjaxBootstrapSelect.js
+++ b/src/js/classes/AjaxBootstrapSelect.js
@@ -241,7 +241,7 @@ var AjaxBootstrapSelect = function (element, options) {
      * @type {AjaxBootstrapSelectList}
      */
     this.list = new window.AjaxBootstrapSelectList(this);
-    this.list.refresh();
+    this.list.refresh(this.options.triggerChange);
 
     // We need for selectpicker to be attached first. Putting the init in a
     // setTimeout is the easiest way to ensure this.

--- a/src/js/classes/AjaxBootstrapSelectList.js
+++ b/src/js/classes/AjaxBootstrapSelectList.js
@@ -287,7 +287,7 @@ AjaxBootstrapSelectList.prototype.replaceOptions = function (data) {
 
     // Replace the options.
     this.plugin.$element.html(output);
-    this.refresh();
+    this.list.refresh(this.plugin.options.triggerChange);
     this.plugin.log(this.plugin.LOG_DEBUG, 'Replaced options with data:', data);
 };
 


### PR DESCRIPTION
## Description (required)

This PR makes the triggering of the `change` event configurable. In the previous versions this event was always triggered and in some cases could be useful to be able to react when the list changes.

## Merge checklist (required, for maintainers only)

This pull request adheres to the following requirements:

- [] JavaScript follows 4 space indentation conventions.
- [] JavaScript was written using ES2015 (ES6) features.
- [] Features and bug fixes are covered by test cases.
- [] All commits follow the _AngularJS Git Commit Message Conventions_.
